### PR TITLE
Added refractory period and absolute threshold

### DIFF
--- a/sparkle/tools/spikestats.py
+++ b/sparkle/tools/spikestats.py
@@ -1,7 +1,17 @@
 """ Here is a doc string for spikestats :)"""
 import numpy as np
 
-def Refractory(times, refract=0.002):
+def refractory(times, refract=0.002):
+    """Removes spikes in times list that do not satisfy refractor period
+
+    :param times: list(float) of spike times in seconds
+    :type times: list(float)
+    :param refract: Refractory period in seconds
+    :type refract: float
+    :returns: list(float) of spike times in seconds
+
+    For every interspike interval < refract, 
+    removes the second spike time in list and returns the result"""
 	times_refract = []
 	times_refract.append(times[0])
 	for i in range(1,len(times)):
@@ -19,7 +29,7 @@ def spike_times(signal, threshold, fs, mint=None):
     :type threshold: float
     :returns: list(float) of spike times in seconds
 
-    For every continuous set of points over given threshold, 
+    For every continuous set of points with absolute value over given threshold, 
     returns the time of the maximum"""
     times = []
     over, = np.where(np.abs(signal)>threshold)

--- a/sparkle/tools/spikestats.py
+++ b/sparkle/tools/spikestats.py
@@ -65,7 +65,7 @@ def spike_times(signal, threshold, fs, mint=None):
         times.append(float(over[0])/fs)
         
     if len(times)>0:
-    	return Refractory(times)
+    	return refractory(times)
     else:
     	return times
 

--- a/sparkle/tools/spikestats.py
+++ b/sparkle/tools/spikestats.py
@@ -1,6 +1,14 @@
 """ Here is a doc string for spikestats :)"""
 import numpy as np
 
+def Refractory(times, refract=0.002):
+	times_refract = []
+	times_refract.append(times[0])
+	for i in range(1,len(times)):
+		if times_refract[-1]+refract <= times[i]:
+			times_refract.append(times[i])        
+	return times_refract
+
 
 def spike_times(signal, threshold, fs, mint=None):
     """Detect spikes from a given signal
@@ -14,7 +22,7 @@ def spike_times(signal, threshold, fs, mint=None):
     For every continuous set of points over given threshold, 
     returns the time of the maximum"""
     times = []
-    over, = np.where(signal>threshold)
+    over, = np.where(np.abs(signal)>threshold)
     segments, = np.where(np.diff(over) > 1)
 
     if len(over) > 1:
@@ -47,7 +55,10 @@ def spike_times(signal, threshold, fs, mint=None):
     elif len(over) == 1:
         times.append(float(over[0])/fs)
         
-    return times
+    if len(times)>0:
+    	return Refractory(times)
+    else:
+    	return times
 
 def bin_spikes(spike_times, binsz):
     """Sort spike times into bins

--- a/sparkle/tools/spikestats.py
+++ b/sparkle/tools/spikestats.py
@@ -2,23 +2,22 @@
 import numpy as np
 
 def refractory(times, refract=0.002):
-    """Removes spikes in times list that do not satisfy refractor period
+	"""Removes spikes in times list that do not satisfy refractor period
 
-    :param times: list(float) of spike times in seconds
-    :type times: list(float)
-    :param refract: Refractory period in seconds
-    :type refract: float
-    :returns: list(float) of spike times in seconds
+	:param times: list(float) of spike times in seconds
+	:type times: list(float)
+	:param refract: Refractory period in seconds
+	:type refract: float
+	:returns: list(float) of spike times in seconds
 
-    For every interspike interval < refract, 
-    removes the second spike time in list and returns the result"""
+	For every interspike interval < refract, 
+	removes the second spike time in list and returns the result"""
 	times_refract = []
 	times_refract.append(times[0])
 	for i in range(1,len(times)):
 		if times_refract[-1]+refract <= times[i]:
 			times_refract.append(times[i])        
 	return times_refract
-
 
 def spike_times(signal, threshold, fs, mint=None):
     """Detect spikes from a given signal


### PR DESCRIPTION
These changes set a 2 sec refractory period to avoid double counting of spikes, particularly when cells are not perfectly isolated or the threshold is set low. Also, the threshold is applied to the absolute value of the signal to include cases where the original threshold was performed on an inverted signal. 