### PR TITLE
Changed mphoneCalBtn and startBtn text for clarity

### DIFF
--- a/sparkle/gui/main_control.py
+++ b/sparkle/gui/main_control.py
@@ -990,7 +990,6 @@ class MainWindow(ControlWindow):
             self.ui.aifsSpnbx.setValue(self.acqmodel.calibration_genrate())
             self.ui.aifsSpnbx.setEnabled(False)
             self.setCalibrationDuration()
-            self.ui.mphoneCalBtn.setText('Calibrate Mic')
             self.ui.startBtn.setText('Calibrate Speaker')
         elif self.prevTab == 'calibration':
             self.ui.aifsSpnbx.setEnabled(True)

--- a/sparkle/gui/main_control.py
+++ b/sparkle/gui/main_control.py
@@ -302,6 +302,8 @@ class MainWindow(ControlWindow):
 
         if str(self.ui.tabGroup.tabText(self.ui.tabGroup.currentIndex())).lower() != 'calibration':
             self.ui.aifsSpnbx.setEnabled(True)
+        else:
+            self.ui.startBtn.setText('Calibrate Speaker')
         self.ui.aochanBox.setEnabled(True)
         reprate = self.ui.reprateSpnbx.setEnabled(True)
         self.ui.stopBtn.setEnabled(False)
@@ -988,9 +990,12 @@ class MainWindow(ControlWindow):
             self.ui.aifsSpnbx.setValue(self.acqmodel.calibration_genrate())
             self.ui.aifsSpnbx.setEnabled(False)
             self.setCalibrationDuration()
+            self.ui.mphoneCalBtn.setText('Calibrate Mic')
+            self.ui.startBtn.setText('Calibrate Speaker')
         elif self.prevTab == 'calibration':
             self.ui.aifsSpnbx.setEnabled(True)
             self.ui.aifsSpnbx.setValue(self.stashedAisr)
+            self.ui.startBtn.setText('Start')
         
         if str(self.ui.tabGroup.tabText(tabIndex)).lower() == 'review' and self.activeOperation != 'explore':
             self.ui.startBtn.setEnabled(False)

--- a/sparkle/gui/main_control.ui
+++ b/sparkle/gui/main_control.ui
@@ -73,7 +73,7 @@
         <item>
          <widget class="QTabWidget" name="tabGroup">
           <property name="currentIndex">
-           <number>0</number>
+           <number>2</number>
           </property>
           <widget class="QWidget" name="tabExplore">
            <attribute name="title">
@@ -342,7 +342,7 @@
                  <string>Start recording microphone calibration tone</string>
                 </property>
                 <property name="text">
-                 <string>calibrate</string>
+                 <string>Calibrate Mic</string>
                 </property>
                </widget>
               </item>
@@ -726,7 +726,7 @@
      <x>0</x>
      <y>0</y>
      <width>1223</width>
-     <height>27</height>
+     <height>21</height>
     </rect>
    </property>
    <widget class="QMenu" name="menuOptions">

--- a/sparkle/gui/main_control_form.py
+++ b/sparkle/gui/main_control_form.py
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
 
-# Form implementation generated from reading ui file 'main_control.ui'
+# Form implementation generated from reading ui file '../../../../../../../Documents/sparkle/sparkle/gui/main_control.ui'
 #
-# Created: Thu May 21 11:03:49 2015
-#      by: PyQt4 UI code generator 4.11.1
+# Created: Mon Jun 08 15:59:01 2015
+#      by: PyQt4 UI code generator 4.10.4
 #
 # WARNING! All changes made in this file will be lost!
 
@@ -369,7 +369,7 @@ class Ui_ControlWindow(object):
         self.verticalLayout_3.addLayout(self.horizontalLayout_5)
         ControlWindow.setCentralWidget(self.centralwidget)
         self.menubar = QtGui.QMenuBar(ControlWindow)
-        self.menubar.setGeometry(QtCore.QRect(0, 0, 1223, 27))
+        self.menubar.setGeometry(QtCore.QRect(0, 0, 1223, 21))
         self.menubar.setObjectName(_fromUtf8("menubar"))
         self.menuOptions = QtGui.QMenu(self.menubar)
         self.menuOptions.setObjectName(_fromUtf8("menuOptions"))
@@ -621,7 +621,7 @@ class Ui_ControlWindow(object):
         self.menubar.addAction(self.menuView.menuAction())
 
         self.retranslateUi(ControlWindow)
-        self.tabGroup.setCurrentIndex(0)
+        self.tabGroup.setCurrentIndex(2)
         QtCore.QObject.connect(self.actionSave_Options, QtCore.SIGNAL(_fromUtf8("triggered()")), ControlWindow.launchSaveDlg)
         QtCore.QObject.connect(self.actionSet_Calibration, QtCore.SIGNAL(_fromUtf8("triggered()")), ControlWindow.launchCalibrationDlg)
         QtCore.QObject.connect(self.actionSet_Scale, QtCore.SIGNAL(_fromUtf8("triggered()")), ControlWindow.launchScaleDlg)
@@ -676,7 +676,7 @@ class Ui_ControlWindow(object):
         self.mphoneDBSpnbx.setToolTip(_translate("ControlWindow", "intensity of microphone calibration device", None))
         self.label_22.setText(_translate("ControlWindow", "dB SPL", None))
         self.mphoneCalBtn.setToolTip(_translate("ControlWindow", "Start recording microphone calibration tone", None))
-        self.mphoneCalBtn.setText(_translate("ControlWindow", "calibrate", None))
+        self.mphoneCalBtn.setText(_translate("ControlWindow", "Calibrate Mic", None))
         self.tabGroup.setTabText(self.tabGroup.indexOf(self.tabCalibrate), _translate("ControlWindow", "Calibration", None))
         self.tabGroup.setTabText(self.tabGroup.indexOf(self.tabReview), _translate("ControlWindow", "Review", None))
         self.aochanBox.setToolTip(_translate("ControlWindow", "Output channel (AO#)", None))


### PR DESCRIPTION
Changed the text for mphoneCalBtn to "Calibrate Mic" and the startBtn text to "Calibrate Speaker" while on the Calibrate tab. This should help users differentiate between calibrating the microphone vs the speaker. Aims to fix #4 