### PR TITLE
user has option to use abs or not on spike thresholding

### DIFF
--- a/sparkle/gui/controlwindow.py
+++ b/sparkle/gui/controlwindow.py
@@ -231,6 +231,7 @@ class ControlWindow(QtGui.QMainWindow):
         for name, deets in self._aichan_details.items():
             self.display.setThreshold(deets['threshold'], name)
             self.display.setRasterBounds(deets['raster_bounds'], name)
+            self.display.setAbs(deets['abs'], name)
 
         # can't find a function in DAQmx that gets the trigger
         # channel names, so add manually
@@ -375,6 +376,13 @@ class ControlWindow(QtGui.QMainWindow):
             self.acqmodel.attenuator_connection(False)
         self._aichans = inputsdict.get('aichans', [])
         self._aichan_details = inputsdict.get('aichan_details', {})
+        for name, deets in self._aichan_details.items():
+            # make sure all field as present in details for each channel
+            self._aichan_details[name]['threshold'] = deets.get('threshold', 5)
+            self._aichan_details[name]['polarity'] = deets.get('polarity', 1)
+            self._aichan_details[name]['raster_bounds'] = deets.get('raster_bounds', (0.5,0.9))
+            self._aichan_details[name]['abs'] = deets.get('abs', True)
+
         self.reset_device_channels()
 
         stim_defaults = inputsdict.get('stim_view_defaults', {})

--- a/sparkle/gui/plotting/protocoldisplay.py
+++ b/sparkle/gui/plotting/protocoldisplay.py
@@ -10,6 +10,7 @@ class ProtocolDisplay(QtGui.QWidget):
     thresholdUpdated = QtCore.Signal(float, str)
     polarityInverted = QtCore.Signal(float, str)
     rasterBoundsUpdated = QtCore.Signal(tuple, str)
+    absUpdated = QtCore.Signal(bool, str)
     def __init__(self, response_chan_name='chan0', parent=None):
         super(ProtocolDisplay, self).__init__(parent)
 
@@ -60,6 +61,7 @@ class ProtocolDisplay(QtGui.QWidget):
         spiketracePlot.thresholdUpdated.connect(self.thresholdUpdated.emit)
         spiketracePlot.polarityInverted.connect(self.polarityInverted.emit)
         spiketracePlot.rasterBoundsUpdated.connect(self.rasterBoundsUpdated.emit)
+        spiketracePlot.absUpdated.connect(self.absUpdated.emit)
         self.colormapChanged = self.specPlot.colormapChanged
 
         # for the purposes of splitter not updating contents...
@@ -101,6 +103,7 @@ class ProtocolDisplay(QtGui.QWidget):
             plot.thresholdUpdated.connect(self.thresholdUpdated.emit)
             plot.polarityInverted.connect(self.polarityInverted.emit)
             plot.rasterBoundsUpdated.connect(self.rasterBoundsUpdated.emit)
+            plot.absUpdated.connect(self.absUpdated.emit)
             self.responsePlots[name] = plot
 
     def removeResponsePlot(self, *names):
@@ -110,6 +113,7 @@ class ProtocolDisplay(QtGui.QWidget):
                 plot.thresholdUpdated.disconnect()
                 plot.polarityInverted.disconnect()
                 plot.rasterBoundsUpdated.disconnect()
+                plot.absUpdated.disconnect()
                 plot.plotItem.vb.sigXRangeChanged.disconnect()
                 plot.close()
                 plot.deleteLater()
@@ -219,6 +223,8 @@ class ProtocolDisplay(QtGui.QWidget):
     def setRasterBounds(self, bounds, plotname):
         self.responsePlots[plotname].setRasterBounds(bounds)
 
+    def setAbs(self, bounds, plotname):
+        self.responsePlots[plotname].setAbs(bounds)
 
 
 if __name__ == "__main__":

--- a/sparkle/tools/spikestats.py
+++ b/sparkle/tools/spikestats.py
@@ -19,19 +19,22 @@ def refractory(times, refract=0.002):
 			times_refract.append(times[i])        
 	return times_refract
 
-def spike_times(signal, threshold, fs, mint=None):
+def spike_times(signal, threshold, fs, absval=True):
     """Detect spikes from a given signal
 
     :param signal: Spike trace recording (vector)
     :type signal: numpy array
     :param threshold: Threshold value to determine spikes
     :type threshold: float
+    :param absval: Whether to apply absolute value to signal before thresholding
+    :type absval: bool
     :returns: list(float) of spike times in seconds
 
-    For every continuous set of points with absolute value over given threshold, 
+    For every continuous set of points over given threshold, 
     returns the time of the maximum"""
     times = []
-    signal = np.abs(signal)
+    if absval:
+        signal = np.abs(signal)
     over, = np.where(signal>threshold)
     segments, = np.where(np.diff(over) > 1)
 

--- a/test/tests/gui/test_main_ui.py
+++ b/test/tests/gui/test_main_ui.py
@@ -62,7 +62,7 @@ class TestMainUI():
         devname = get_devices()[0]
         self.form.advanced_options['device_name'] = devname
         self.form._aichans = [devname+'/ai0']
-        self.form._aichan_details = {devname+'/ai0': {'threshold': 5, 'polarity': 1, 'raster_bounds':(0.5,0.9)}}
+        self.form._aichan_details = {devname+'/ai0': {'threshold': 5, 'polarity': 1, 'raster_bounds':(0.5,0.9), 'abs': True}}
         self.form.reset_device_channels()
         self.form.show()
         # so that the data display doesn't get in the way of out
@@ -119,8 +119,8 @@ class TestMainUI():
     def test_explore_multichannel(self):
         devname = get_devices()[0]
         self.form._aichans = [devname+'/ai0', devname+'/ai1']
-        self.form._aichan_details = {devname+'/ai0': {'threshold': 5, 'polarity': 1, 'raster_bounds':(0.5,0.9)},
-                                     devname+'/ai1': {'threshold': 5, 'polarity': 1, 'raster_bounds':(0.5,0.9)}}
+        self.form._aichan_details = {devname+'/ai0': {'threshold': 5, 'polarity': 1, 'raster_bounds':(0.5,0.9), 'abs': True},
+                                     devname+'/ai1': {'threshold': 5, 'polarity': 1, 'raster_bounds':(0.5,0.9), 'abs': True}}
         self.form.reset_device_channels()
         QtTest.QTest.qWait(ALLOW)
         assert self.form.display.responsePlotCount() == 2
@@ -255,8 +255,8 @@ class TestMainUI():
     def test_tone_protocol_multichannel(self):
         devname = get_devices()[0]
         self.form._aichans = [devname+'/ai0', devname+'/ai1']
-        self.form._aichan_details = {devname+'/ai0': {'threshold': 5, 'polarity': 1, 'raster_bounds':(0.5,0.9)},
-                                     devname+'/ai1': {'threshold': 5, 'polarity': 1, 'raster_bounds':(0.5,0.9)}}
+        self.form._aichan_details = {devname+'/ai0': {'threshold': 5, 'polarity': 1, 'raster_bounds':(0.5,0.9), 'abs': True},
+                                     devname+'/ai1': {'threshold': 5, 'polarity': 1, 'raster_bounds':(0.5,0.9), 'abs': True}}
         self.form.reset_device_channels()
         QtTest.QTest.qWait(ALLOW)
         assert self.form.display.responsePlotCount() == 2

--- a/test/tests/unit/tools/test_spikestats.py
+++ b/test/tests/unit/tools/test_spikestats.py
@@ -17,22 +17,25 @@ def test_spike_times_sin():
     threshold = 0.7
     fs = 10
 
-    times = spike_times(y, threshold, fs)
+    times_abs = spike_times(y, threshold, fs)
+    times_orginal = spike_times(y, threshold, fs, False)
 
     # abs when detecting spikes, gets both humps of sine wave
-    assert len(times) == fq*2
+    assert len(times_abs) == fq*2
+    assert len(times_orginal) == fq
 
     # calculate where the peaks will be for sin wave
     period = (float(n)/10)/16
     peak_time = period/4
-    print period, peak_time
-    sin_peak_times = np.arange(0,102.4,period/2)+peak_time
+    # print period, peak_time
+    sin_peak_times_all = np.arange(0,102.4,period/2)+peak_time
+    sin_peak_times_max = np.arange(0,102.4,period)+peak_time
 
-    print sin_peak_times, times
+    # print sin_peak_times_all, times_abs
     # very small rounding errors different for different calc methods
-    assert np.allclose(sin_peak_times, times, atol=0.00000001)
+    assert np.allclose(sin_peak_times_all, times_abs, atol=0.00000001)
+    assert np.allclose(sin_peak_times_max, times_orginal, atol=0.00000001)
 
-@unittest.skip("messed up with spike detection using abs")
 def test_spike_times_sample_syl():
     """ Not realistic, but complex"""
     sylpath = sample.samplewav()
@@ -40,13 +43,10 @@ def test_spike_times_sample_syl():
     wavdata = wavdata.astype(float)/np.max(wavdata)
     threshold = 0.8
 
-    times = spike_times(wavdata, threshold, fs)
+    times = spike_times(wavdata, threshold, fs, absval=False)
 
-    # manually found outwith
-    control_times = [ 0.039461,  0.039704,  0.039717,  0.039819,  0.039896,  0.039933,
-        0.039984,  0.039997,  0.040048,  0.04024,   0.040304,  0.040507,  0.04052,
-        0.040597,  0.040712,  0.040763,  0.040776,  0.040968,  0.041005,  0.04144,
-        0.043683,  0.043824]
+    # manually found outwith -- with 2ms refractory
+    control_times = [0.039461, 0.043683]
 
     assert np.allclose(control_times, times, atol=0.00000001)
 


### PR DESCRIPTION
Resolves #10  The user can toggle off applying the absolute value to the recording signal before spike detection. On applied on a channel-by-channel basis.