### PR TITLE
Development Mode

### DIFF
--- a/doc/ref/api.rst
+++ b/doc/ref/api.rst
@@ -37,7 +37,7 @@ This application was built using National Instruments (NI) hardware and drivers.
 
 Custom :mod:`task classes<sparkle.acq.daq_tasks>` exist for calling the NI drivers, these classes are based off of the C examples provided by NI.
 
-Higher level :mod:`player classes<sparkle.acq.players>` faciliate the repetitive and windowed nature of the recording this program is intended to execute. That said, continuous acquisition is also a goal, and there is a separate player class for this type of task.
+Higher level :mod:`player classes<sparkle.acq.players>` facilitate the repetitive and windowed nature of the recording this program is intended to execute. That said, continuous acquisition is also a goal, and there is a separate player class for this type of task.
 
 NI provides simulated devices so that it is possible to develop applications without needing the actual hardware connected to the computer. However, this is only for the windows platform, so the module :mod:`daqmx_stub<sparkle.acq.daqmx_stub>` stands in to allow development on the rest of the program without errors being thrown.
 
@@ -48,7 +48,7 @@ Stimulus Classes
 
 The main container for an individual stimulus is the :class:`StimulusModel<sparkle.stim.stimulus_model>`. Internally, the stimulus is composed of a 2D array (nested lists) of components which are any subclass of :class:`AbstractStimulusComponent<sparkle.stim.abstract_component>`. These classes are required to implement a ``signal`` function (not to be confused with signals/slots of Qt), which is used by StimulusModel to sum its components to get the total signal for the desired stimulus. This allows for creation of any stimulus imaginable through the ability to overlap components, and to define custom component classes.
 
-On its own, a StimulusModel represents a single stimulus signal (the sum of it's components). To create auto-tests (automatic component manipulation, e.g. a tuning curve), The ``StimlulusModel`` uses the information held in its :class:`AutoParameterModel<sparkle.stim.auto_parameter_model>` attribute to modify itself in a loop, and collect all the resultant signals, yielding a list of signals to generate.
+On its own, a StimulusModel represents a single stimulus signal (the sum of its components). To create auto-tests (automatic component manipulation, e.g. a tuning curve), The ``StimlulusModel`` uses the information held in its :class:`AutoParameterModel<sparkle.stim.auto_parameter_model>` attribute to modify itself in a loop, and collect all the resultant signals, yielding a list of signals to generate.
 
 Any number of ``StimulusModel`s` can be collected in a list via a :class:`ProtocolModel<sparkle.run.protocol_model>`, to be generated independent of each other, in sequence.
 
@@ -60,7 +60,7 @@ The list of ``StimlusModel`s` inside of a ``ProtocolModel``, and the list of com
 
 Discovery of the stimulus components classes, by the UI, is automatic, with the intention to make it easier to add new component classes. The modules under the source folder `sparkle/stim/types` are searched for subclasses of ``AbstractStimulusComponent`.` Depending on flags set in each class, the component class will be pulled in to be available for explore, protocol or both operations by the UI.
 
-For further information related to adding additional Stimulus Component classes see :doc:`Extending spikey<extending>`
+For further information related to adding additional Stimulus Component classes see :doc:`Extending sparkle<extending>`
 
 Speaker Calibration
 ++++++++++++++++++++
@@ -122,7 +122,7 @@ The plotting is built upon the pyqtgraph_ library. All custom plots widgets are 
 
 The plot widgets are arranged into displays: 
 
-    * :class:`ProtocolDisplay<sparkle.gui.plotting.protocoldisplay.ProtocolDisplay>`: Main display for visualizing the the auditory stimulus and brain recording. Stimulus is shown in spectrogram, time signal, and FFT plots. Brain recording trace includes a raster plot of spike detection, which has an adjustable threshold.
+    * :class:`ProtocolDisplay<sparkle.gui.plotting.protocoldisplay.ProtocolDisplay>`: Main display for visualizing the auditory stimulus and brain recording. Stimulus is shown in spectrogram, time signal, and FFT plots. Brain recording trace includes a raster plot of spike detection, which has an adjustable threshold.
     * :class:`CalibrationDisplay<sparkle.gui.plotting.calibration_display.CalibrationDisplay>` : Has two plots that show the generated and recorded signals as FFT plots.
     * :class:`ExtendedCalibrationDisplay<sparkle.gui.plotting.calibration_explore_display.ExtendedCalibrationDisplay>` : Shows the generated and recorded signals each as a spectrogram, time signal and FFT plot.
 
@@ -136,7 +136,7 @@ All types of data files are accessed using the abstract :class:`AcquisitionData<
 
 The file format chosen to save data to is HDF5. Reasons for choosing this file format:
 
-    * Ability to load a file without having to load all it's contents in memory
+    * Ability to load a file without having to load all its contents in memory
     * self-describing: can save metadata/stimulus info along data
     * popular among scientists : not developed in house means anyone can access it without custom code
     * Mature, been around a while and has 2 sets of python bindings
@@ -151,7 +151,7 @@ In :class:`HDF5Data<sparkle.data.hdf5data.HDF5Data>`, the class which handles da
 Explanation of implementation:
 >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
 
-Upon file opening (new or load), a copy of the entire file is made and saved to a (hidden) backup folder created in the directory where the data file is. Each time a test segment finishes, that segment gets saved to it's own backup file in the same folder. These files have incrementing filenames based off of the original data filename. If the program exits normally and closes the original datafile successfully, these backup data files are deleted. If the program crashes, this will not happen, and thus they will be present next time sparkle is started.
+Upon file opening (new or load), a copy of the entire file is made and saved to a (hidden) backup folder created in the directory where the data file is. Each time a test segment finishes, that segment gets saved to its own backup file in the same folder. These files have incrementing filenames based off of the original data filename. If the program exits normally and closes the original datafile successfully, these backup data files are deleted. If the program crashes, this will not happen, and thus they will be present next time sparkle is started.
 
 When an HDF5File is opened it checks for the presence of these backup files, and it if finds them, it rebuilds the datafile from these pieces. It renames the original file, to get it out of the way, and renames the re-built data file with the original name. It then carries on with the normal backup procedure. That the File checks for backups before loading the original is important... if a file is corrupted it may still be able to be opened, but data may still be missing; it is then harmful to backup this corrupted data, as it will clean up the previous backup in the process. Therefore, if there is evidence of a crash we do not trust the original data by default.
 
@@ -164,7 +164,7 @@ This program uses the python :py:mod:`logging` module. The logging configuration
 
 Testing
 --------
-Everything that can be tested, should be tested. There is a testing utility package, originally wrote for this project, but that has been split off, qtbot_. This package simulates user interaction with the GUI, to allow for testing GUI components themselves, and that the appropriate results from using them happen. New functionality should be accompanied by tests.
+Everything that can be tested should be tested. There is a testing utility package, originally wrote for this project, but that has been split off, qtbot_. This package simulates user interaction with the GUI, to allow for testing GUI components themselves, and that the appropriate results from using them happen. New functionality should be accompanied by tests.
 
 .. _qtbot : https://github.com/boylea/qtbot
 
@@ -200,7 +200,12 @@ Any time a change is made to the source code, it should be made sure that the do
 Extending
 ---------
 
-See :doc:`Extending spikey<extending>`
+See :doc:`Extending sparkle<extending>`
+
+Develop Mode
+------------
+
+While running Sparkle, it is not uncommon that you may be running without any hardware connected. If this is the case and pydaqmx is not installed, Sparkle will run in Review Mode. Review Mode hides the explore and calibration tabs on the main interface. While this may be convenient for users, programmers developing new features may need to access this. To accommodate, Sparkle will check for the environment variable SPARKLE_DEBUG. If SPARKLE_DEBUG is set to “true” (not case sensitive) Sparkle will not run in Review Mode. This way the explore and calibration tabs will always display, even if pydaqmx is not installed on your machine. 
 
 Reference API
 -------------

--- a/doc/ref/api.rst
+++ b/doc/ref/api.rst
@@ -202,10 +202,10 @@ Extending
 
 See :doc:`Extending sparkle<extending>`
 
-Develop Mode
-------------
+Developer Mode
+--------------
 
-While running Sparkle, it is not uncommon that you may be running without any hardware connected. If this is the case and pydaqmx is not installed, Sparkle will run in Review Mode. Review Mode hides the explore and calibration tabs on the main interface. While this may be convenient for users, programmers developing new features may need to access this. To accommodate, Sparkle will check for the environment variable SPARKLE_DEBUG. If SPARKLE_DEBUG is set to “true” (not case sensitive) Sparkle will not run in Review Mode. This way the explore and calibration tabs will always display, even if pydaqmx is not installed on your machine. 
+While running Sparkle, it is not uncommon that you may be running without any hardware connected. If this is the case and pydaqmx is not installed, Sparkle will run in Review Mode. Review Mode hides the explore and calibration tabs on the main interface. While this may be convenient for users, programmers developing new features may need to access this. To accommodate, Sparkle will check for the environment variable SPARKLE_DEVELOP. If SPARKLE_DEVELOP is set to “true” (not case sensitive) Sparkle will not run in Review Mode. This way the explore and calibration tabs will always display, even if pydaqmx is not installed on your machine. 
 
 Reference API
 -------------

--- a/doc/ref/api.rst
+++ b/doc/ref/api.rst
@@ -182,15 +182,15 @@ If you are on Windows you can run the following from command prompt::
 
 The documentation can now be viewed by opening `_build\html\index.html` with your browser.
 
-In order to properly generate graphics used in the documenation, Graphviz_ will need to be installed on your computer.
+In order to properly generate graphics used in the documenation, Graphviz_ will need to be installed on your computer. Be sure to add the path to Graphviz's dot.exe to your PATH
 
 If unable to build from either the makefile or make.bat, the following command will build the documentation::
 
-    $ sphinx-build -b html -D graphiviz_dot='<path to dot.exe>' . _build
+    $ sphinx-build -b html -D graphviz_dot='<path to dot.exe>' . _build
 
 e.g. ::
 
-    $ sphinx-build -b html -D graphiviz_dot='C:\GraphvizX.XX\bin\dot.exe' . _build
+    $ sphinx-build -b html -D graphviz_dot='C:\GraphvizX.XX\bin\dot.exe' . _build
 
 Any time a change is made to the source code, it should be made sure that the documentation, including the docstrings, API reference, and user guide, is up to date in the same commit. General improvements to the documentation are always welcome.
 

--- a/sparkle/gui/run.py
+++ b/sparkle/gui/run.py
@@ -4,6 +4,8 @@ import time
 import traceback
 import sys
 
+import os
+
 from sparkle.QtWrapper import QtCore, QtGui
 from sparkle.gui.dialogs import SavingDialog
 from sparkle.gui.main_control import MainWindow
@@ -20,7 +22,21 @@ def log_uncaught(*exc_info):
     logger = logging.getLogger('main')
     logger.error("Uncaught exception: ", exc_info=exc_info)
 
+def debug_mode():
+    sparkle_develop = os.environ.get('SPARKLE_DEVELOP')
+    if (sparkle_develop.upper() != 'TRUE'):
+        #print 'Not in develop mode'
+        return True
+    else:
+        print 'Entering Developer Mode'
+        return False
+
 def main():
+    #print 'results: ', debug_mode()
+    global REVIEWMODE
+    if (REVIEWMODE):
+        REVIEWMODE = debug_mode()
+
     # this is the entry point for the whole application
     logger = logging.getLogger('main')
     logger.info("{} Program Started {}, user: {} {}".format('*'*8, time.strftime("%d-%m-%Y"), getpass.getuser(), '*'*8))

--- a/sparkle/gui/run.py
+++ b/sparkle/gui/run.py
@@ -63,7 +63,7 @@ def main():
                 plenty_space.append((drive, space))
         if len(low_space) > 0:
             if len(plenty_space) > 0:
-                msg = "Waring: At least one Hard disk has low free space:\n\nDrives with low space:\n"
+                msg = "Warning: At least one Hard disk has low free space:\n\nDrives with low space:\n"
                 for drive in low_space:
                     msg = msg + "{} : {} MB\n".format(drive[0], drive[1])
                 msg = msg + "\nDrives with more space:\n"
@@ -72,7 +72,7 @@ def main():
                 msg = msg + "\nYou are advised to only save data to a drive with enough available space"
                 QtGui.QMessageBox.warning(None, "Drive space low", msg)
             else:
-                msg = "Waring: All Hard disks have low free space:\n\n"
+                msg = "Warning: All Hard disks have low free space:\n\n"
                 for drive in low_space:
                     msg = msg + "{} : {} MB\n".format(drive[0], drive[1])
                 msg = msg + "\nIt is recommended that you free up space on a drive before conducting experiments"

--- a/sparkle/gui/run.py
+++ b/sparkle/gui/run.py
@@ -22,20 +22,26 @@ def log_uncaught(*exc_info):
     logger = logging.getLogger('main')
     logger.error("Uncaught exception: ", exc_info=exc_info)
 
-def debug_mode():
+def enable_review_mode():
+    ''' Checks if there is an environment variable named SPARKLE_DEVELOP. 
+        If SPARKLE_DEVELOP exists and is equal to true, enable_review_mode() will
+        return false.
+        Is SPARKLE_DEVELOP exists and is not equal to true, enable_review_mode()
+        will return true.
+        If SPARKLE_DEVELOP does not exist enable_review_mode() will return True.'''
     sparkle_develop = os.environ.get('SPARKLE_DEVELOP')
+    if sparkle_develop is None:
+        sparkle_develop = 'False'
     if (sparkle_develop.upper() != 'TRUE'):
-        #print 'Not in develop mode'
         return True
     else:
         print 'Entering Developer Mode'
         return False
 
 def main():
-    #print 'results: ', debug_mode()
     global REVIEWMODE
     if (REVIEWMODE):
-        REVIEWMODE = debug_mode()
+        REVIEWMODE = enable_review_mode()
 
     # this is the entry point for the whole application
     logger = logging.getLogger('main')


### PR DESCRIPTION
Added the ability to look for the environment variable "SPARKLE_DEVELOP". If it is set to "True" the program will display the explore and calibration tabs even if not connected to hardware. 

Aims to fix #14 